### PR TITLE
Update definition of a valid prefix

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddToFolderParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddToFolderParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -17,8 +18,7 @@ public class AddToFolderParser implements Parser<AddToFolderCommand> {
      * @throws ParseException if the given {@code folderName} is invalid.
      */
     public AddToFolderCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
-        List<String> allValues = argMultimap.getAllValues(new Prefix(""));
+        List<String> allValues = new ArrayList<>(Arrays.asList(args.split("\\s+")));
         if (allValues.size() <= 3) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddToFolderCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/CreateFolderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateFolderCommandParser.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.List;
-
 import seedu.address.logic.commands.CreateFolderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.folder.Folder;
@@ -17,32 +15,11 @@ public class CreateFolderCommandParser implements Parser<CreateFolderCommand> {
      * @throws ParseException if the given {@code folderName} is invalid.
      */
     public CreateFolderCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
-        List<String> allValues = argMultimap.getAllValues(new Prefix(""));
-        if (allValues.size() <= 1) {
+        if (args.length() == 0) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CreateFolderCommand.MESSAGE_USAGE));
         }
-        FolderName folderName = extractFolderName(allValues);
-
+        FolderName folderName = ParserUtil.parseFolderName(args);
         return new CreateFolderCommand(new Folder(folderName));
     }
 
-    /**
-     * Extracts the elements relevant to the folder name from {@code List} of inputs
-     * and returns a folder name {@code String}
-     * @param allValues {@code List} of inputs
-     * @return folder name {@code String}
-     * @throws ParseException if the given {@code folderName} is invalid.
-     */
-    private FolderName extractFolderName(List<String> allValues) throws ParseException {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 1; i < allValues.size(); i++) {
-            if (i > 1) {
-                stringBuilder.append(" ").append(allValues.get(i));
-                continue;
-            }
-            stringBuilder.append(allValues.get(i));
-        }
-        return ParserUtil.parseFolderName(stringBuilder.toString());
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteFolderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteFolderCommandParser.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.List;
-
 import seedu.address.logic.commands.DeleteFolderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.folder.Folder;
@@ -17,33 +15,11 @@ public class DeleteFolderCommandParser implements Parser<DeleteFolderCommand> {
      * @throws ParseException if the given {@code folderName} is invalid.
      */
     public DeleteFolderCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
-        List<String> allValues = argMultimap.getAllValues(new Prefix(""));
-        if (allValues.size() <= 1) {
+        if (args.length() == 0) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteFolderCommand.MESSAGE_USAGE));
         }
-        FolderName folderName = extractFolderName(allValues);
-
+        FolderName folderName = ParserUtil.parseFolderName(args);
         return new DeleteFolderCommand(new Folder(folderName));
-    }
-
-    /**
-     * Extracts the elements relevant to the folder name from {@code List} of inputs
-     * and returns a folder name {@code String}
-     * @param allValues {@code List} of inputs
-     * @return folder name {@code String}
-     * @throws ParseException if the given {@code folderName} is invalid.
-     */
-    private FolderName extractFolderName(List<String> allValues) throws ParseException {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 1; i < allValues.size(); i++) {
-            if (i > 1) {
-                stringBuilder.append(" ").append(allValues.get(i));
-                continue;
-            }
-            stringBuilder.append(allValues.get(i));
-        }
-        return ParserUtil.parseFolderName(stringBuilder.toString());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeletePersonFromFolderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePersonFromFolderCommandParser.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.List;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeletePersonFromFolderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,13 +18,11 @@ public class DeletePersonFromFolderCommandParser
      * @throws ParseException if the given index and folder name is invalid.
      */
     public DeletePersonFromFolderCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
-        List<String> allValues = argMultimap.getAllValues(new Prefix(""));
-        if (allValues.size() <= 1) {
+        if (args.length() == 0) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeletePersonFromFolderCommand.MESSAGE_USAGE));
         }
-        String[] inputsToConvertToCommand = extractProperInputs(allValues);
+        String[] inputsToConvertToCommand = extractIndividualFolderAndIndex(args);
         assert inputsToConvertToCommand.length == 2
                 : "Should have exactly 2 inputs of Index and Folder strings only!";
 
@@ -60,22 +56,6 @@ public class DeletePersonFromFolderCommandParser
         return ParserUtil.parseIndex(indexString);
     }
 
-
-    /**
-     * Extracts the elements relevant to the
-     * folder names and index from {@code List} of inputs
-     * and returns string of index and folder name {@code String[]}.
-     * @param allValues {@code List} of inputs
-     * @return folder name and index strings {@code String[]}
-     * @throws ParseException if the given string inputs are invalid.
-     */
-    private String[] extractProperInputs(List<String> allValues)
-            throws ParseException {
-        String indexAndFolderJoined = buildProperInputs(allValues);
-        String[] indexAndFolderParts = extractIndividualFolderAndIndex(indexAndFolderJoined);
-        return indexAndFolderParts;
-    }
-
     /**
      * Segments the joined string of folder name and index into
      * individual {@code String[]} objects.
@@ -106,21 +86,4 @@ public class DeletePersonFromFolderCommandParser
         return inputsOfIndexAndFolder;
     }
 
-
-    /**
-     * Concatenates the multiple inputs into a single string.
-     * @param allValues {@code List} of inputs
-     * @return concatenated inputs consisting of Index and Folder {@code String}
-     */
-    private String buildProperInputs(List<String> allValues) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 1; i < allValues.size(); i++) {
-            if (i > 1) {
-                stringBuilder.append(" ").append(allValues.get(i));
-                continue;
-            }
-            stringBuilder.append(allValues.get(i));
-        }
-        return stringBuilder.toString();
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/EditFolderNameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditFolderNameCommandParser.java
@@ -2,8 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.List;
-
 import seedu.address.logic.commands.EditFolderNameCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.folder.Folder;
@@ -22,31 +20,14 @@ public class EditFolderNameCommandParser implements Parser<EditFolderNameCommand
      * @throws ParseException if the given {@code folderName} is invalid.
      */
     public EditFolderNameCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, new Prefix(""));
-        List<String> allValues = argMultimap.getAllValues(new Prefix(""));
-        if (allValues.size() <= 1) {
+        if (args.length() == 0) {
             throw new ParseException(String.format(
-                    MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditFolderNameCommand.MESSAGE_USAGE));
+                    MESSAGE_INVALID_COMMAND_FORMAT, EditFolderNameCommand.MESSAGE_USAGE));
         }
-        FolderName[] folderNames = extractFolderNames(allValues);
+        FolderName[] folderNames = extractIndividualFolders(args);
         assert folderNames.length == 2 : "Should have exactly 2 folders only!";
 
         return new EditFolderNameCommand(new Folder(folderNames[0]), new Folder(folderNames[1]));
-    }
-
-    /**
-     * Extracts the elements relevant to the
-     * folder names from {@code List} of inputs
-     * and returns 2 folder names {@code FolderName[]}
-     * @param allValues {@code List} of inputs
-     * @return folder names {@code FolderName[]}
-     * @throws ParseException if the given {@code folderNames} are invalid.
-     */
-    private FolderName[] extractFolderNames(List<String> allValues) throws ParseException {
-        String folderStringNames = buildFolderStringNames(allValues);
-        FolderName[] allFolderNames = extractIndividualFolders(folderStringNames);
-        return allFolderNames;
     }
 
     /**
@@ -78,23 +59,6 @@ public class EditFolderNameCommandParser implements Parser<EditFolderNameCommand
         }
 
         return allFolderNames;
-    }
-
-    /**
-     * Concatenates the multiple folder names into a single string.
-     * @param allValues {@code List} of inputs
-     * @return concatenated folder names {@code String}
-     */
-    private String buildFolderStringNames(List<String> allValues) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 1; i < allValues.size(); i++) {
-            if (i > 1) {
-                stringBuilder.append(" ").append(allValues.get(i));
-                continue;
-            }
-            stringBuilder.append(allValues.get(i));
-        }
-        return stringBuilder.toString();
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -82,7 +82,7 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_multipleArguments() {
         // Only two arguments are present
-        String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
+        String argsString = "SomePreambleString -t dashT-Value p/ pSlash value";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
@@ -90,7 +90,7 @@ public class ArgumentTokenizerTest {
         assertArgumentAbsent(argMultimap, hatQ);
 
         // All three arguments are present
-        argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
+        argsString = "Different Preamble String ^Q 111 -t dashT-Value p/ pSlash value";
         argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "Different Preamble String");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");


### PR DESCRIPTION
Previously, a valid prefix must have a preceding whitespace

Now, there is an added condition that there must be a whitespace after the prefix OR the prefix is at the end of the string

This is to be in line with unix flags such as `vim 1 -n New Name` and `vim 1 -t`