### PR TITLE
Fix Echo command bugs and vague error messages

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,7 +84,7 @@ Format: `touch -n NAME -p PHONE_NUMBER -e EMAIL -a ADDRESS [-t TAG]…​`
 
 * `PHONE_NUMBER` accepts any length to allow for phone formats from different countries.
 * `NAME` has a character limit of 70 characters.
-* `Name` is case-sensitive as John Doe and john doe will be treated as different people
+* `NAME` is case-sensitive as John Doe and john doe will be treated as different people
 * `ADDRESS` is truncated by an ellipsis if the contents cannot fit in one line.
 * Duplicate tags are ignored.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,7 +84,7 @@ Format: `touch -n NAME -p PHONE_NUMBER -e EMAIL -a ADDRESS [-t TAG]…​`
 
 * `PHONE_NUMBER` accepts any length to allow for phone formats from different countries.
 * `NAME` has a character limit of 70 characters.
-* `NAME` is case-sensitive as John Doe and john doe will be treated as different people
+* `NAME` is case-sensitive as John Doe and john doe will be treated as different people.
 * `ADDRESS` is truncated by an ellipsis if the contents cannot fit in one line.
 * Duplicate tags are ignored.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,6 +84,7 @@ Format: `touch -n NAME -p PHONE_NUMBER -e EMAIL -a ADDRESS [-t TAG]…​`
 
 * `PHONE_NUMBER` accepts any length to allow for phone formats from different countries.
 * `NAME` has a character limit of 70 characters.
+* `Name` is case-sensitive as John Doe and john doe will be treated as different people
 * `ADDRESS` is truncated by an ellipsis if the contents cannot fit in one line.
 * Duplicate tags are ignored.
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_INDEX_EXCEEDS_LIST_SIZE = "Person with this index does not exist";
     private static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person%2$s listed!";
     private static final String MESSAGE_FOLDERS_LISTED_OVERVIEW = "%1$d folder%2$s listed!";
 

--- a/src/main/java/seedu/address/logic/commands/AddToFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddToFolderCommand.java
@@ -18,7 +18,7 @@ public class AddToFolderCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to folder in UNIon. "
             + "Parameters: "
-            + "INDEX >> FOLDERNAME \n"
+            + "CONTACT_INDEX >> FOLDERNAME \n"
             + "Example: "
             + COMMAND_WORD + " "
             + "3 >> CS2103";
@@ -47,7 +47,7 @@ public class AddToFolderCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
         for (Index index : this.indexList) {
             if (index.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                throw new CommandException(Messages.MESSAGE_INVALID_INDEX_EXCEEDS_LIST_SIZE);
             }
 
             Person personToAdd = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/parser/AddToFolderParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddToFolderParser.java
@@ -70,7 +70,9 @@ public class AddToFolderParser implements Parser<AddToFolderCommand> {
                 i--;
                 allValues.remove(currString);
             } catch (NumberFormatException e) {
-                continue;
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AddToFolderCommand.MESSAGE_USAGE));
+
             }
         }
         return contactsToAdd;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -21,7 +21,7 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Person with this index does not exist";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be


### PR DESCRIPTION
1. Resolve bug `echo David >> Foldername` being able to add a contact when it's supposed to throw an error
2. Changed error message when a user enters invalid index for the echo command
Eg. `echo -1 >> cs2103` or `echo 100000 >> cs2103`
3. Modified documentation to explain why `john doe`, `John Doe` and `John  Doe` can be added to the same folder as they are treated as different contacts(Issue raised from Mock PE)