### PR TITLE
Fix method of checking that the user input starts with command word

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -111,4 +111,20 @@ public class StringUtil {
         requireNonNull(s);
         return String.join(" ", s.split("\\s+")).trim();
     }
+
+    /**
+     * Checks if a sentence starts with a given command
+     *
+     * The command must be followed by a whitespace character or the end of the string
+     *
+     * @param sentence Sentence to check if it starts with a given command, which may have leading/trailing spaces
+     * @param command Given command, which may have spaces in the middle but not leading/trailing
+     * @return Whether the given sentence starts with the given command
+     */
+    public static boolean startsWithCommand(String sentence, String command) {
+        assert command.trim().equals(command); // command should not have leading or trailing spaces
+        requireNonNull(command);
+        String cleanSentence = removeExtraWhitespace(sentence);
+        return cleanSentence.startsWith(command + " ") || cleanSentence.equals(command);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -44,8 +44,7 @@ public class AddressBookParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
-        String trimmedUserInput = StringUtil.removeExtraWhitespace(userInput);
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(trimmedUserInput);
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
@@ -53,39 +52,39 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
         // using if-else and String.startsWith() instead of switch-case
         // allows for the flexibility of having commands with multiple words, e.g. rm -contacts
-        if (trimmedUserInput.startsWith(AddCommand.COMMAND_WORD)) {
+        if (StringUtil.startsWithCommand(userInput, AddCommand.COMMAND_WORD)) {
             return new AddCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(EditFolderNameCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, EditFolderNameCommand.COMMAND_WORD)) {
             return new EditFolderNameCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(DeleteFolderCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, DeleteFolderCommand.COMMAND_WORD)) {
             return new DeleteFolderCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(EditCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, EditCommand.COMMAND_WORD)) {
             return new EditCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(ClearCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, ClearCommand.COMMAND_WORD)) {
             return new ClearCommand();
-        } else if (trimmedUserInput.startsWith(ClearFoldersCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, ClearFoldersCommand.COMMAND_WORD)) {
             return new ClearFoldersCommand();
-        } else if (trimmedUserInput.startsWith(DeleteCommand.COMMAND_WORD)
-                || trimmedUserInput.startsWith(DeletePersonFromFolderCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, DeleteCommand.COMMAND_WORD)
+                || StringUtil.startsWithCommand(userInput, DeletePersonFromFolderCommand.COMMAND_WORD)) {
             if (arguments.contains(DeletePersonFromFolderCommand.COMMAND_IDENTIFIER)) {
                 return new DeletePersonFromFolderCommandParser().parse(arguments);
             }
             return new DeleteCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(FindFoldersCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, FindFoldersCommand.COMMAND_WORD)) {
             return new FindFoldersCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(FindCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, FindCommand.COMMAND_WORD)) {
             return new FindCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(ListFoldersCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, ListFoldersCommand.COMMAND_WORD)) {
             return new ListFoldersCommand();
-        } else if (trimmedUserInput.startsWith(ListCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, ListCommand.COMMAND_WORD)) {
             return new ListCommand();
-        } else if (trimmedUserInput.startsWith(ExitCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, ExitCommand.COMMAND_WORD)) {
             return new ExitCommand();
-        } else if (trimmedUserInput.startsWith(HelpCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, HelpCommand.COMMAND_WORD)) {
             return new HelpCommand();
-        } else if (trimmedUserInput.startsWith(CreateFolderCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, CreateFolderCommand.COMMAND_WORD)) {
             return new CreateFolderCommandParser().parse(arguments);
-        } else if (trimmedUserInput.startsWith(AddToFolderCommand.COMMAND_WORD)) {
+        } else if (StringUtil.startsWithCommand(userInput, AddToFolderCommand.COMMAND_WORD)) {
             return new AddToFolderParser().parse(arguments);
         } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -265,4 +265,51 @@ public class StringUtilTest {
         assertEquals(StringUtil.removeExtraWhitespace("words    more    words       -flag"), "words more words -flag");
         assertEquals(StringUtil.removeExtraWhitespace("words \t \n words"), "words words");
     }
+
+    //---------------- Tests for startsWithCommand --------------------------------------
+    /*
+     * Equivalence Partitions for sentence:
+     * - null
+     * - empty string
+     * - sentence with extra spaces (leading or trailing or in between words)
+     * - sentence with one word
+     * - sentence with multiple words
+     *
+     * Equivalence Partitions for word:
+     * - null
+     * - empty string
+     * - valid word
+     *
+     * Possible scenarios returning true:
+     * - sentence starts with word and then the string ends
+     * - sentence starts with word followed by a whitespace character
+     * - ignoring leading spaces, sentence starts with word
+     *
+     * Possible scenarios returning false:
+     * - sentence does not start with word
+     * - sentence starts with word but followed by non-whitespace character
+     *
+     */
+
+    @Test
+    public void startsWithCommand_nullGiven_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.startsWithCommand(null, "word"));
+        assertThrows(NullPointerException.class, () -> StringUtil.startsWithCommand("a a a a", null));
+    }
+
+    @Test
+    public void startsWithCommand_validInputs_correctResult() {
+        // Possible scenarios returning true
+        assertTrue(StringUtil.startsWithCommand("", ""));
+        assertTrue(StringUtil.startsWithCommand("   ls -contacts", "ls -contacts"));
+        assertTrue(StringUtil.startsWithCommand("command argument1 argument2", "command"));
+        assertTrue(StringUtil.startsWithCommand(" \n  command argument1 argument2", "command"));
+
+        // Possible scenarios returning false
+        assertFalse(StringUtil.startsWithCommand("sentence", "")); // no extra space
+        assertFalse(StringUtil.startsWithCommand("", "command"));
+        assertFalse(StringUtil.startsWithCommand("sentence", "command"));
+        assertFalse(StringUtil.startsWithCommand("helpppp", "help")); // main use case for this method
+        assertFalse(StringUtil.startsWithCommand("rmm 3", "rm")); // main use case for this method
+    }
 }


### PR DESCRIPTION
Stuff to test

- `helpp` should not work (previously did)
- `exitt` should not work (previously did)
- `rmm 3` should not work (previously did)
- `(space)(space)ls -contacts` should still work (unchanged behaviour but may be affected)

And any other related things you can think of