### PR TITLE
Standardize error msg for diff EPs

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,9 +8,9 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
 
-    public static final String MESSAGE_INVALID_FOLDER_IN_UNION = "This folder does not exist in UNIon";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_PERSON_IN_UNION = "This person does not exist in UNIon";
+    public static final String MESSAGE_NONEXISTENT_FOLDER_IN_CURRENT_LIST = "Folder name supplied "
+            + "is not found in the current folder's list below.";
     private static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person%2$s listed!";
     private static final String MESSAGE_FOLDERS_LISTED_OVERVIEW = "%1$d folder%2$s listed!";
 

--- a/src/main/java/seedu/address/logic/commands/AddToFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddToFolderCommand.java
@@ -56,7 +56,7 @@ public class AddToFolderCommand extends Command {
         }
 
         if (indexOfFolder == -1) {
-            throw new CommandException(Messages.MESSAGE_INVALID_FOLDER_IN_UNION);
+            throw new CommandException(Messages.MESSAGE_NONEXISTENT_FOLDER_IN_CURRENT_LIST);
         }
 
         for (Index index : this.indexList) {

--- a/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
@@ -45,7 +45,7 @@ public class DeleteFolderCommand extends Command {
         int indexOfFolder = lastShownFolderList.indexOf(folderToRemove);
 
         if (indexOfFolder == -1) {
-            throw new CommandException(Messages.MESSAGE_INVALID_FOLDER_IN_UNION);
+            throw new CommandException(Messages.MESSAGE_NONEXISTENT_FOLDER_IN_CURRENT_LIST);
         }
 
         model.deleteFolder(folderToRemove);

--- a/src/main/java/seedu/address/logic/commands/DeletePersonFromFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonFromFolderCommand.java
@@ -65,7 +65,7 @@ public class DeletePersonFromFolderCommand extends Command {
         }
 
         if (indexOfFolder == -1) {
-            throw new CommandException(Messages.MESSAGE_INVALID_FOLDER_IN_UNION);
+            throw new CommandException(Messages.MESSAGE_NONEXISTENT_FOLDER_IN_CURRENT_LIST);
         }
 
         Person personToRemove = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/EditFolderNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditFolderNameCommand.java
@@ -56,7 +56,7 @@ public class EditFolderNameCommand extends Command {
         List<Folder> lastShownFolderList = model.getFilteredFolderList();
         int indexOfFolder = lastShownFolderList.indexOf(oldFolder);
         if (indexOfFolder == -1) {
-            throw new CommandException(Messages.MESSAGE_INVALID_FOLDER_IN_UNION);
+            throw new CommandException(Messages.MESSAGE_NONEXISTENT_FOLDER_IN_CURRENT_LIST);
         }
 
         if (model.hasFolder(newFolder)) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -48,15 +48,17 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
-        //Check for - symbol as first element
+        // Check for - symbol as first element (or negative index)
         if (firstElement == 45) {
-            throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+            throw new ParseException(String.format(ParserUtil.MESSAGE_INVALID_INDEX, preamble));
         }
 
+        // Check for String input as person index
         for (int i = 0; i < preamble.length(); i++) {
             char element = preamble.charAt(i);
             if (!Character.isDigit(element)) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        EditCommand.MESSAGE_USAGE));
             }
         }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -21,7 +21,7 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_INDEX = "The index '%1$s' is invalid. It should be a positive integer";
     public static final String MESSAGE_OVERFLOW_INTEGER = "UNIon is unable to handle such a large integer";
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -38,7 +38,7 @@ public class ParserUtil {
 
         //Check for - symbol or 0 as first element
         if (firstElement == 45 || firstElement == 48) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(String.format(MESSAGE_INVALID_INDEX, trimmedIndex));
         }
 
         //Check if all values are integers only

--- a/src/test/java/seedu/address/logic/parser/DeletePersonFromFolderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeletePersonFromFolderCommandParserTest.java
@@ -49,7 +49,7 @@ public class DeletePersonFromFolderCommandParserTest {
     @Test
     public void parse_properFolderAndInvalidIndex_failure() {
         String successStringInput = " -1 >> TestFolder1";
-        String expectedErrorMessage = ParserUtil.MESSAGE_INVALID_INDEX;
+        String expectedErrorMessage = String.format(ParserUtil.MESSAGE_INVALID_INDEX, "-1");
         DeletePersonFromFolderCommandParser deletePersonFromFolderCommandParser =
                 new DeletePersonFromFolderCommandParser();
         assertParseFailure(

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -67,10 +67,12 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY,
+                String.format(ParserUtil.MESSAGE_INVALID_INDEX, "-5"));
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY,
+                String.format(ParserUtil.MESSAGE_INVALID_INDEX, "0"));
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_FOLDER_NAME_CCA;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_OVERFLOW_INTEGER;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -49,10 +49,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1),
-                new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddToFolderCommand.MESSAGE_USAGE))));
+        assertThrows(ParseException.class, MESSAGE_OVERFLOW_INTEGER, ()
+            -> ParserUtil.parseIndex("1000000000000",
+                new ParseException(MESSAGE_OVERFLOW_INTEGER)));
     }
 
     @Test


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46375597/140612052-8492a967-7f55-40d9-8c92-ef7806eb8877.png)

<br>

![image](https://user-images.githubusercontent.com/46375597/140612091-d1998d0c-bca4-40d4-8e4e-824025564f9f.png)

<br>

![image](https://user-images.githubusercontent.com/46375597/140612071-fd1341b3-41f5-402e-a5e9-a862c11230c1.png)

<br>

Note: When index is given as a String, such as `rm sebastian`, `vim sebastian -n "Benjamin"`, it will output `Invalid Command Format!` instead.